### PR TITLE
Increasing Archi support (including v4.7, v4.8, v4.9)

### DIFF
--- a/lib/processors/InputProcessingDirector/InputProcessorDirector.js
+++ b/lib/processors/InputProcessingDirector/InputProcessorDirector.js
@@ -68,7 +68,10 @@ class InputProcessorDirector {
                             modelVersion.startsWith("4.3") ||
                             modelVersion.startsWith("4.4") || // Tested
                             modelVersion.startsWith("4.5") ||
-                            modelVersion.startsWith("4.6") // Tested
+                            modelVersion.startsWith("4.6") || // Tested
+                            modelVersion.startsWith("4.7") ||
+                            modelVersion.startsWith("4.8") ||
+                            modelVersion.startsWith("4.9") // Tested
                         )
                     ) {
                         interpreter = new Archi4Interpreter(xmlFile);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@arktect-co/archimate-model-importer",
   "author": "diorbert.pereira",
   "repository": "github:Arktect-Co/archimate-model-importer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "In memory Archimate model importer compatible with Archi (.archimate), AOEFF and GRAFICO (distributed Archi file)",
   "dependencies": {
     "lodash": "^4.17.20",


### PR DESCRIPTION
This PR increases the support for Archi, allowing the processing of files from versions v4.7, v4.8 and v4.9.